### PR TITLE
Remove node_modules from app structure from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@ _randomNumber.js_ - Generates the dice results for the board game.
 
 _validator.js_ - Validates all user input for obviously reasons.
 
-**node_modules**-Folder:
-
-Stores all required npm packages for this app.
-
 ## Architecture diagrams
 
 TODO: Add diagrams


### PR DESCRIPTION
node_modules is generated folder from npm. It's not really part of the project. It's natural/expected to have node_modules folder when you work with Node.js. 
How you want to call something "part of the project" if it's in .gitignore (except secret configs and stuff...)